### PR TITLE
remove ability to provide chezmoi config in `/config`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ permissions: ## set script permissions
 
 run: stop setup-dirs ## run container with `/init` as the entrypoint to run s6-overlay
 	@docker container rm $(PROJECT_NAME) >/dev/null 2>&1 || true;
-	@docker container run --detach \
+	@docker container run --detach --rm \
 		--name $(PROJECT_NAME) \
 		--env "CHEZMOI_REPO=ITProKyle" \
 		--volume "$$PWD/tmp/config:/config" \

--- a/README.md
+++ b/README.md
@@ -65,25 +65,19 @@ Configuration is done through a combination of environment variables and volumes
 
 #### `/config`
 
-The `/config` volume is used to store the majority of persistent [code-server] & SSH data.
-
-| Path within `/config`               | Description                                                                                                                 |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `chezmoi.(json\|jsonc\|toml\|yaml)` | [`chezmoi`] config file that will be symlinked to `/root/.config/chezmoi/chezmoi.<format>` (extension based on file format) |
+The `/config` volume is used to store the majority of configuration files and persistant data.
 
 #### `/root/.local/share/chezmoi`
 
 While optional, a volume can be used to cache the [`chezmoi`] git repository.
 
-> [!NOTE]
-> This directory is symlinked to `.local/share/chezmoi` of the non-root user.
-
 ```yaml
-service-name:
-  volumes:
-    - source: chezmoi-repo
-      target: /root/.local/share/chezmoi
-      type: volume
+services:
+  service-name:
+    volumes:
+      - source: chezmoi-repo
+        target: /root/.local/share/chezmoi
+        type: volume
 
 volumes:
   chezmoi-repo:

--- a/rootfs/etc/s6-overlay/s6-rc.d/init-adduser/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-adduser/run
@@ -1,30 +1,14 @@
 #! /usr/bin/with-contenv oi
 # shellcheck shell=bash
-readonly -a CHEZMOI_FORMATS=("json" "jsonc" "toml" "yaml")
 declare ARG_UID="${_UID:-568}";
 declare ARG_GID="${_GID:-568}";
 declare ARG_USER="${_USER:-admin}";
-
-function symlink::chezmoi.config {
-  # Symlink chezmoi config from /config to user home.
-  #
-  local user_home="${1:-/root}";
-  local chezmoi_config="${2:-chezmoi.toml}";
-
-  mkdir -p "${user_home}/.config/chezmoi" \
-    || oi::exit.error "Failed to create chezmoi config directory '${user_home}'";
-  ln -s "/config/${chezmoi_config}" "${user_home}/.config/chezmoi/${chezmoi_config}" \
-    || oi::exit.error "Failed to symlink '/config/${chezmoi_config}' to '${user_home}/.config/chezmoi/${chezmoi_config}'";
-}
 
 function init::chezmoi {
   # Initialize chezmoi or check of updates if already initialized.
   #
   local repo="${1:-}";  # repo that chezmoi will checkout and apply
   local user_name="${2:-admin}"  # name of non-root user
-  local user_home="/home/${user_name}";  # root chezmoi setup will be symlinked here
-  local _config_is_symlink="false";
-  local _config_file
 
   if oi::var.is_empty "${repo}"; then
     oi::log.info "git repo for chezmoi managed dotfiles not provided";
@@ -38,29 +22,6 @@ function init::chezmoi {
     chezmoi init "${repo}" --apply --color true \
       || oi::exit.error "Failed to initialize & apply chezmoi dotfiles";
   fi
-
-  for fmt in "${CHEZMOI_FORMATS[@]}"; do
-    if [[ -L "/root/.config/chezmoi/chezmoi.${fmt}" ]]; then
-      _config_is_symlink="true";
-      _config_file="chezmoi.${fmt}"
-    fi
-  done
-
-  if oi::var.is_false "${_config_is_symlink}"; then
-    mv "/root/.config/chezmoi/${_config_file}" "/config/${_config_file}" \
-      || oi::exit.error "Failed to move chezmoi config to '/config' directory";
-    symlink::chezmoi.config "/root" "${_config_file}";
-  fi
-
-  if ! oi::fs.directory_exists "${user_home}/.local/share/chezmoi"; then
-    mkdir -p "${user_home}/.local/share" \
-      || oi::exit.error "Failed to create directory '${user_home}/.local/share'";
-    lsiown "${user_name}:${user_name}" "${user_home}/.local/share" \
-      || oi::exit.error "Failed to change ownership of '${user_home}/.local/share'";
-  fi
-
-  ln -s "/root/.local/share/chezmoi" "${user_home}/.local/share/chezmoi" \
-    || oi::exit.error "Failed to symlink '/root/.local/share/chezmoi' to '${user_home}/.local/share/chezmoi'";
 }
 
 function init::user {
@@ -97,12 +58,4 @@ function init::user {
 }
 
 init::user "${ARG_USER}" "${ARG_GID}" "${ARG_UID}";
-
-for fmt in "${CHEZMOI_FORMATS[@]}"; do
-  if oi::fs.file_exists "/config/chezmoi.${fmt}"; then
-    symlink::chezmoi.config "/root" "chezmoi.${fmt}";
-    symlink::chezmoi.config "/home/${ARG_USER}" "chezmoi.${fmt}";
-  fi
-done
-
 init::chezmoi "${CHEZMOI_REPO:-}";


### PR DESCRIPTION
each time `chezmoi init` is run, it replace the symlink rather than updating the file contents making the symlink virtually useless.